### PR TITLE
allow configuration of multiple loggers by their prefix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths: ["**.go"]
     branches: [default]
-    types: [synchronize]
+    types: [opened, synchronize, edited, reopened]
 
 # TODO This should run across all '-latest' platforms
 # Write code coverage results to file

--- a/README.md
+++ b/README.md
@@ -38,3 +38,24 @@ The second precedent are `ENV` variables prefixed with `LOG_LEVEL_`. These varia
 - `LOG_LEVEL_ERROR=1 LOG_LEVEL_WARN=0 ...`
 - `LOG_LEVEL_ERROR=0 LOG_LEVEL_DEBUG=0 LOG_LEVEL_INFO=1 ...`
 - `LOG_LEVEL_ERROR=0 LOG_LEVEL_DEBUG=0 LOG_LEVEL_INFO=0 LOG_LEVEL_WARN=1 ...`
+
+# Multiple Loggers
+
+To configure specific loggers, prefix the `ENV` variable with the same prefix used for that logger. Configuration of log levels set for specific loggers will take priority over non-prefixed `LOG_LEVEL_` configuration.
+
+e.g., if you need a `renderLogger` and a `computationalLogger`, you might create them like this
+
+```
+	renderLogger := logger.New("renderer", logger.DefaultSeverity)
+	computeLogger := logger.New("computer", logger.DefaultSeverity)
+```
+
+The default severity may be fine for most situations but for testing you may want additional `DEBUG` log messages from the `computeLogger`.
+
+In that case, in the `ENV` of whatever is running tests, you can define
+
+```
+compute_LOG_LEVEL_DEBUG=1
+```
+
+and the `computeLogger` will additionally show `DEBUG` messages while the `renderLogger` will only show messages under the default severity (`WARN` and `ERROR`).

--- a/log_test.go
+++ b/log_test.go
@@ -34,7 +34,8 @@ func runTest(
 	testLogger *logger.Logger,
 	testCall callback,
 	channel logger.Severity,
-	message, channelLabel string,
+	message string,
+	channelLabel logger.ChannelLabel,
 	writer *strings.Builder,
 ) {
 	testCall(message)
@@ -51,63 +52,63 @@ func runTest(
 	}
 }
 
-func testError(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
+func testError(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Error
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func testWarn(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
+func testWarn(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Warn
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func testInfo(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
+func testInfo(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Info
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func testDebug(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
+func testDebug(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Debug
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func logLevelError(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
+func logLevelError(t *testing.T, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
 	testFunction := testLogger.Error
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func logLevelWarn(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
+func logLevelWarn(t *testing.T, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
 	testFunction := testLogger.Warn
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func logLevelInfo(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
+func logLevelInfo(t *testing.T, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
 	testFunction := testLogger.Info
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func logLevelDebug(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
+func logLevelDebug(t *testing.T, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
 	testFunction := testLogger.Debug
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
-func prefixedLogger(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
+func prefixedLogger(t *testing.T, channel logger.Severity, channelLabel logger.ChannelLabel, prefix, message string) {
 	loggerBDebugLogLevel := fmt.Sprintf("%v_LOG_LEVEL_%v", prefix, logger.ChannelLabelDebug)
 	t.Setenv(loggerBDebugLogLevel, enabledValue)
 

--- a/log_test.go
+++ b/log_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	prefix           = "Test"
+	defaultPrefix    = "Test"
 	testMessageError = "Test error message"
 	testMessageWarn  = "Test warn message"
 	testMessageInfo  = "Test info message"
@@ -23,7 +23,7 @@ const (
 
 type callback func(f string, v ...any)
 
-func prepare(severity logger.Severity) (writer *strings.Builder, testLogger *logger.Logger) {
+func prepare(severity logger.Severity, prefix string) (writer *strings.Builder, testLogger *logger.Logger) {
 	writer = &strings.Builder{}
 	testLogger = logger.New(prefix, severity, writer, writer)
 	return
@@ -44,7 +44,7 @@ func runTest(
 	}
 
 	receivedMessage := writer.String()
-	expectedSuffix := fmt.Sprintf("[%v] [%v] %v\n", channelLabel, prefix, message)
+	expectedSuffix := fmt.Sprintf("[%v] [%v] %v\n", channelLabel, defaultPrefix, message)
 
 	if !strings.HasSuffix(receivedMessage, expectedSuffix) {
 		t.Errorf("'%v' != '%v'", message, receivedMessage)
@@ -52,56 +52,67 @@ func runTest(
 }
 
 func testError(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(loggerSeverity)
+	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Error
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
 func testWarn(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(loggerSeverity)
+	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Warn
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
 func testInfo(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(loggerSeverity)
+	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Info
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
 func testDebug(t *testing.T, loggerSeverity logger.Severity, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(loggerSeverity)
+	writer, testLogger := prepare(loggerSeverity, prefix)
 	testFunction := testLogger.Debug
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
 func logLevelError(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(logger.DefaultSeverity)
+	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
 	testFunction := testLogger.Error
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
 func logLevelWarn(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(logger.DefaultSeverity)
+	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
 	testFunction := testLogger.Warn
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
 func logLevelInfo(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(logger.DefaultSeverity)
+	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
 	testFunction := testLogger.Info
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
 }
 
 func logLevelDebug(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
-	writer, testLogger := prepare(logger.DefaultSeverity)
+	writer, testLogger := prepare(logger.DefaultSeverity, prefix)
+	testFunction := testLogger.Debug
+
+	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
+}
+
+func prefixedLogger(t *testing.T, channel logger.Severity, channelLabel, prefix, message string) {
+	loggerBDebugLogLevel := fmt.Sprintf("%v_LOG_LEVEL_%v", prefix, logger.ChannelLabelDebug)
+	t.Setenv(loggerBDebugLogLevel, enabledValue)
+
+	writer := &strings.Builder{}
+	testLogger := logger.New(defaultPrefix, logger.DefaultSeverity, writer, writer)
 	testFunction := testLogger.Debug
 
 	runTest(t, testLogger, testFunction, channel, message, channelLabel, writer)
@@ -113,14 +124,14 @@ func TestError(t *testing.T) {
 	message := testMessageError
 
 	t.Run("Default Error", func(t *testing.T) {
-		testError(t, logger.DefaultSeverity, channel, channelLabel, prefix, message)
+		testError(t, logger.DefaultSeverity, channel, channelLabel, defaultPrefix, message)
 	})
 	t.Run("Only Error", func(t *testing.T) {
-		testError(t, logger.Error, channel, channelLabel, prefix, message)
+		testError(t, logger.Error, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Except Error", func(t *testing.T) {
-		testError(t, logger.Warn|logger.Info|logger.Debug, channel, channelLabel, prefix, message)
+		testError(t, logger.Warn|logger.Info|logger.Debug, channel, channelLabel, defaultPrefix, message)
 	})
 }
 
@@ -130,13 +141,13 @@ func TestWarn(t *testing.T) {
 	message := testMessageWarn
 
 	t.Run("Default Warn", func(t *testing.T) {
-		testWarn(t, logger.DefaultSeverity, channel, channelLabel, prefix, message)
+		testWarn(t, logger.DefaultSeverity, channel, channelLabel, defaultPrefix, message)
 	})
 	t.Run("Only Warn", func(t *testing.T) {
-		testWarn(t, logger.Warn, channel, channelLabel, prefix, message)
+		testWarn(t, logger.Warn, channel, channelLabel, defaultPrefix, message)
 	})
 	t.Run("Except Warn", func(t *testing.T) {
-		testWarn(t, logger.Error|logger.Info|logger.Debug, channel, channelLabel, prefix, message)
+		testWarn(t, logger.Error|logger.Info|logger.Debug, channel, channelLabel, defaultPrefix, message)
 	})
 }
 
@@ -146,13 +157,13 @@ func TestInfo(t *testing.T) {
 	message := testMessageInfo
 
 	t.Run("Default Info", func(t *testing.T) {
-		testInfo(t, logger.DefaultSeverity, channel, channelLabel, prefix, message)
+		testInfo(t, logger.DefaultSeverity, channel, channelLabel, defaultPrefix, message)
 	})
 	t.Run("Only Info", func(t *testing.T) {
-		testInfo(t, logger.Info, channel, channelLabel, prefix, message)
+		testInfo(t, logger.Info, channel, channelLabel, defaultPrefix, message)
 	})
 	t.Run("Except Info", func(t *testing.T) {
-		testInfo(t, logger.Error|logger.Warn|logger.Debug, channel, channelLabel, prefix, message)
+		testInfo(t, logger.Error|logger.Warn|logger.Debug, channel, channelLabel, defaultPrefix, message)
 	})
 }
 
@@ -162,116 +173,130 @@ func TestDebug(t *testing.T) {
 	message := testMessageDebug
 
 	t.Run("Default Debug", func(t *testing.T) {
-		testDebug(t, logger.DefaultSeverity, channel, channelLabel, prefix, message)
+		testDebug(t, logger.DefaultSeverity, channel, channelLabel, defaultPrefix, message)
 	})
 	t.Run("Only Debug", func(t *testing.T) {
-		testDebug(t, logger.Debug, channel, channelLabel, prefix, message)
+		testDebug(t, logger.Debug, channel, channelLabel, defaultPrefix, message)
 	})
 	t.Run("Except Debug", func(t *testing.T) {
-		testDebug(t, logger.Error|logger.Warn|logger.Info, channel, channelLabel, prefix, message)
+		testDebug(t, logger.Error|logger.Warn|logger.Info, channel, channelLabel, defaultPrefix, message)
 	})
 }
 
 func TestLogLevelError(t *testing.T) {
 	channel := logger.Error
 	channelLabel := logger.ChannelLabelError
+	envVariable := fmt.Sprintf("LOG_LEVEL_%v", channelLabel)
 	message := testMessageError
 
 	t.Run("Default Severity Error LogLevel Disabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), disabledValue)
-		logLevelError(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, disabledValue)
+		logLevelError(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Error LogLevel Enabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), enabledValue)
-		logLevelError(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, enabledValue)
+		logLevelError(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Error LogLevel Undetermined", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), undeterminedValue)
-		logLevelError(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, undeterminedValue)
+		logLevelError(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Error LogLevel Bogus", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), bogusValue)
-		logLevelError(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, bogusValue)
+		logLevelError(t, channel, channelLabel, defaultPrefix, message)
 	})
 }
 
 func TestLogLevelWarn(t *testing.T) {
 	channel := logger.Warn
 	channelLabel := logger.ChannelLabelWarn
+	envVariable := fmt.Sprintf("LOG_LEVEL_%v", channelLabel)
 	message := testMessageWarn
 
 	t.Run("Default Severity Warn LogLevel Disabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), disabledValue)
-		logLevelWarn(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, disabledValue)
+		logLevelWarn(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Warn LogLevel Enabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), enabledValue)
-		logLevelWarn(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, enabledValue)
+		logLevelWarn(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Warn LogLevel Undetermined", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), undeterminedValue)
-		logLevelWarn(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, undeterminedValue)
+		logLevelWarn(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Warn LogLevel Bogus", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelWarn), bogusValue)
-		logLevelWarn(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, bogusValue)
+		logLevelWarn(t, channel, channelLabel, defaultPrefix, message)
 	})
 }
 
 func TestLogLevelInfo(t *testing.T) {
 	channel := logger.Info
 	channelLabel := logger.ChannelLabelInfo
+	envVariable := fmt.Sprintf("LOG_LEVEL_%v", channelLabel)
 	message := testMessageInfo
 
 	t.Run("Default Severity Info LogLevel Disabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelInfo), disabledValue)
-		logLevelInfo(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, disabledValue)
+		logLevelInfo(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Info LogLevel Enabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelInfo), enabledValue)
-		logLevelInfo(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, enabledValue)
+		logLevelInfo(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Info LogLevel Undetermined", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelInfo), undeterminedValue)
-		logLevelInfo(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, undeterminedValue)
+		logLevelInfo(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Info LogLevel Bogus", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelInfo), bogusValue)
-		logLevelInfo(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, bogusValue)
+		logLevelInfo(t, channel, channelLabel, defaultPrefix, message)
 	})
 }
 
 func TestLogLevelDebug(t *testing.T) {
 	channel := logger.Debug
 	channelLabel := logger.ChannelLabelDebug
+	envVariable := fmt.Sprintf("LOG_LEVEL_%v", channelLabel)
 	message := testMessageDebug
 
 	t.Run("Default Severity Debug LogLevel Disabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelDebug), disabledValue)
-		logLevelDebug(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, disabledValue)
+		logLevelDebug(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Debug LogLevel Enabled", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelDebug), enabledValue)
-		logLevelDebug(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, enabledValue)
+		logLevelDebug(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Debug LogLevel Undetermined", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelDebug), undeterminedValue)
-		logLevelDebug(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, undeterminedValue)
+		logLevelDebug(t, channel, channelLabel, defaultPrefix, message)
 	})
 
 	t.Run("Default Severity Debug LogLevel Bogus", func(t *testing.T) {
-		t.Setenv(string(logger.LogLevelDebug), bogusValue)
-		logLevelDebug(t, channel, channelLabel, prefix, message)
+		t.Setenv(envVariable, bogusValue)
+		logLevelDebug(t, channel, channelLabel, defaultPrefix, message)
+	})
+}
+
+func TestLoggerLogLevelPrefix(t *testing.T) {
+	channel := logger.Debug
+	channelLabel := logger.ChannelLabelDebug
+	message := testMessageDebug
+
+	t.Run("Default Severity Prefixed Logger", func(t *testing.T) {
+		prefixedLogger(t, channel, channelLabel, defaultPrefix, message)
 	})
 }


### PR DESCRIPTION
and:

- adjust the readme to reflect current logging configurables

Fixes #5 